### PR TITLE
Revert "ci: bump nerdyscout/kicad-exports from v2.0 to v2.1"

### DIFF
--- a/.github/workflows/hardware.check.yaml
+++ b/.github/workflows/hardware.check.yaml
@@ -25,7 +25,7 @@ jobs:
 
     # RUN
     - name: kicad-exports erc
-      uses: nerdyscout/kicad-exports@v2.1
+      uses: nerdyscout/kicad-exports@v2.0
       with:
         config: ./.config/erc.kiplot.yaml
         dir: hardware
@@ -41,7 +41,7 @@ jobs:
 
     # RUN
     - name: kicad-exports drc
-      uses: nerdyscout/kicad-exports@v2.1
+      uses: nerdyscout/kicad-exports@v2.0
       with:
         config: ./.config/drc.kiplot.yaml
         dir: hardware

--- a/.github/workflows/hardware.docs.yaml
+++ b/.github/workflows/hardware.docs.yaml
@@ -20,7 +20,7 @@ jobs:
 
     # RUN
     - name: kicad-exports schematics
-      uses: nerdyscout/kicad-exports@v2.1
+      uses: nerdyscout/kicad-exports@v2.0
       with:
         config: ./.config/schematics.kiplot.yaml
         dir: hardware/docs
@@ -50,7 +50,7 @@ jobs:
         submodules: 'recursive'
     # RUN
     - name: kicad-exports bom
-      uses: nerdyscout/kicad-exports@v2.1
+      uses: nerdyscout/kicad-exports@v2.0
       with:
         config: ./.config/bom.kiplot.yaml
         dir: hardware/docs/bom
@@ -82,7 +82,7 @@ jobs:
 
     # RUN
     - name: kicad-exports plot
-      uses: nerdyscout/kicad-exports@v2.1
+      uses: nerdyscout/kicad-exports@v2.0
       with:
         config: ./.config/plot.kiplot.yaml
         dir: hardware/docs/imgs
@@ -112,7 +112,7 @@ jobs:
 
     # RUN
     - name: kicad-exports model
-      uses: nerdyscout/kicad-exports@v2.1
+      uses: nerdyscout/kicad-exports@v2.0
       with:
         config: ./.config/model.kiplot.yaml
         dir: hardware/docs/cad
@@ -140,7 +140,7 @@ jobs:
 
     # RUN
     - name: kicad-exports gerbers
-      uses: nerdyscout/kicad-exports@v2.1
+      uses: nerdyscout/kicad-exports@v2.0
       with:
         config: ./.config/gerbers.kiplot.yaml
         dir: hardware/docs/gerbers


### PR DESCRIPTION
Reverts ZeniteSolar/MCB19#18

#18 results in the following error (see [here](https://github.com/ZeniteSolar/MCB19/runs/1280901377?check_suite_focus=true#step:4:90)):
```PowerShell
PermissionError: [Errno 13] Permission denied: '/github/home/.config'
DEBUG:Checking if /github/workspace/hardware/MCB19.pro was modified (eeschema_do.kiauto.file_util - file_util.py:241)
ERROR:ERC returned 1 (kibot.kibot.pre_erc - pre_erc.py:45)
```